### PR TITLE
fix the height of " table of contents "

### DIFF
--- a/styles/readtheorg/js/readtheorg.js
+++ b/styles/readtheorg/js/readtheorg.js
@@ -38,6 +38,12 @@ $( document ).ready(function() {
 
     // add sticky table headers
     $('table').stickyTableHeaders();
+
+    var $postamble = $('#postamble');
+    var $tableOfContents = $('#table-of-contents');
+    // set the height of tableOfContents
+    $tableOfContents.height($tableOfContents.height() - $postamble.outerHeight());
+
 });
 
 window.SphinxRtdTheme = (function (jquery) {


### PR DESCRIPTION
The height of " table of contents " is 100% now, so that the bottom part of " table of contents " would be covered by " postamble " block if there are too many list in it.

thank you