### PR TITLE
fix table and contents overlaps on mobile

### DIFF
--- a/styles/readtheorg/css/readtheorg.css
+++ b/styles/readtheorg/css/readtheorg.css
@@ -61,7 +61,7 @@ body{
 #content{
     background:#fcfcfc;
     height:100%;
-    margin-left:300px;
+    left:300px;
     /* margin:auto; */
     max-width:800px;
     min-height:100%;


### PR DESCRIPTION
margin-left seems not working on ios safari nor android chrome