### PR TITLE
make ReadTheOrg responsive

### DIFF
--- a/styles/readtheorg/css/readtheorg.css
+++ b/styles/readtheorg/css/readtheorg.css
@@ -1034,4 +1034,50 @@ h2.footnotes{
     /* padding: 10px 20px 10px 60px; */
     padding: 9px 12px;
     margin-bottom: 24px;
-    font-family:"Roboto Slab","ff-tisa-web-pro","Georgia",Arial,sans-serif}
+    font-family:"Roboto Slab","ff-tisa-web-pro","Georgia",Arial,sans-serif
+}
+
+
+
+
+
+
+
+/******** responsive for sidebar *******/
+
+#toggle-sidebar {
+    display: none;
+}
+
+@media screen and (max-width: 768px) {
+    #table-of-contents {
+        display: none;
+        width: 60%;
+    }
+
+    #table-of-contents h2 a {
+        display: block;
+    }
+
+    #table-of-contents:target {
+        display: block;
+    }
+
+    #copyright, #postamble {
+        display: none;
+    }
+
+    #toggle-sidebar {
+        display: block;
+        background-color: #E0D6E9;
+        text-align: center;
+        padding: 0.6em;
+        margin-bottom: 0.6em;
+    }
+    #toggle-sidebar h2 {
+        margin: 0;
+        padding: 0;
+    }
+}
+
+/******** End responsive for sidebar *******/

--- a/styles/readtheorg/css/readtheorg.css
+++ b/styles/readtheorg/css/readtheorg.css
@@ -1045,7 +1045,8 @@ h2.footnotes{
 
 /******** responsive for sidebar *******/
 
-#toggle-sidebar {
+#toggle-sidebar,
+#table-of-contents .close-sidebar {
     display: none;
 }
 
@@ -1077,6 +1078,10 @@ h2.footnotes{
     #toggle-sidebar h2 {
         margin: 0;
         padding: 0;
+    }
+
+    #table-of-contents .close-sidebar {
+      display: block;
     }
 }
 

--- a/styles/readtheorg/js/readtheorg.js
+++ b/styles/readtheorg/js/readtheorg.js
@@ -39,10 +39,15 @@ $( document ).ready(function() {
     // add sticky table headers
     $('table').stickyTableHeaders();
 
+
+    // set the height of tableOfContents
     var $postamble = $('#postamble');
     var $tableOfContents = $('#table-of-contents');
-    // set the height of tableOfContents
     $tableOfContents.height($tableOfContents.height() - $postamble.outerHeight());
+
+    // add TOC button
+    var toggleSidebar = $('<div id="toggle-sidebar"><a href="#table-of-contents"><h2>Table of Contents</h2></a></div>');
+    $('#content').prepend(toggleSidebar);
 
 });
 

--- a/styles/readtheorg/js/readtheorg.js
+++ b/styles/readtheorg/js/readtheorg.js
@@ -43,7 +43,7 @@ $( document ).ready(function() {
     // set the height of tableOfContents
     var $postamble = $('#postamble');
     var $tableOfContents = $('#table-of-contents');
-    $tableOfContents.height($tableOfContents.height() - $postamble.outerHeight());
+    $tableOfContents.css({paddingBottom: $postamble.outerHeight()});
 
     // add TOC button
     var toggleSidebar = $('<div id="toggle-sidebar"><a href="#table-of-contents"><h2>Table of Contents</h2></a></div>');

--- a/styles/readtheorg/js/readtheorg.js
+++ b/styles/readtheorg/js/readtheorg.js
@@ -49,6 +49,11 @@ $( document ).ready(function() {
     var toggleSidebar = $('<div id="toggle-sidebar"><a href="#table-of-contents"><h2>Table of Contents</h2></a></div>');
     $('#content').prepend(toggleSidebar);
 
+    // add close button when sidebar showed in mobile screen
+    var closeBtn = $('<a class="close-sidebar" href="#">Close</a>');
+    var tocTitle = $('#table-of-contents').find('h2');
+    tocTitle.append(closeBtn);
+
 });
 
 window.SphinxRtdTheme = (function (jquery) {


### PR DESCRIPTION
Support mobile screen for ReadTheOrg.
The appearance after change you could refer to:

- [GeekPlux's Wiki](http://geekplux.com/wiki/)
- [Master Emacs in 21 Days](http://book.emacs-china.org)


fix #25 

