### PR TITLE
update path of jquery.stickytableheaders.js

### DIFF
--- a/setup/theme-readtheorg.setup
+++ b/setup/theme-readtheorg.setup
@@ -5,5 +5,5 @@
 
 #+HTML_HEAD: <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 #+HTML_HEAD: <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
-#+HTML_HEAD: <script type="text/javascript" src="http://www.pirilampo.org/styles/lib/js/jquery.stickytableheaders.js"></script>
+#+HTML_HEAD: <script type="text/javascript" src="http://www.pirilampo.org/styles/lib/js/jquery.stickytableheaders.min.js"></script>
 #+HTML_HEAD: <script type="text/javascript" src="http://www.pirilampo.org/styles/readtheorg/js/readtheorg.js"></script>


### PR DESCRIPTION
Update the location of jquery.stickytableheaders.js to avoid 404 error: #44 . It is proposed to use the compressed version available of this javascript. 