### PR TITLE
able to access subsections on mobile devices now

### DIFF
--- a/styles/readtheorg/css/readtheorg.css
+++ b/styles/readtheorg/css/readtheorg.css
@@ -437,11 +437,18 @@ table tr:nth-child(2n) td{
     }
 
     #toggle-sidebar h2 {
+		background-color:#2980B9;
+		width:100%;
+		height:50px;
+		left:0;
+		top:0;
         color: white;
         font-size: 100%;
         line-height: 50px;
+		position:fixed;
         margin: 0;
         padding: 0;
+		opacity:0.7;
     }
 
     #table-of-contents .close-sidebar {


### PR DESCRIPTION
Hello, my colleague wanted to navigate through his file but couldn't access the subsections of his navigation. I fixed the table of contents div and set it slightly transparent. You can now click/tap on it, select an item in the navigation having subitems and it will close, but if you click/tap on it again, you can see the subsections and can click on them.