### PR TITLE
Elide tags from minitoc

### DIFF
--- a/styles/bigblow/js/bigblow.js
+++ b/styles/bigblow/js/bigblow.js
@@ -47,8 +47,10 @@ $(function() {
 function generateMiniToc(divId) {
     $('#minitoc').empty().append('<h2>In this section</h2>');
     $('#' + divId).find('h3').each(function(i) {
+        let pos = $(this).text().search(" ");
+        let text = $(this).text().substring(0, pos);
         $("#minitoc").append("<a href='#" + $(this).attr("id") + "'>"
-                             + $(this).text() + "</a>");
+                             + text + "</a>");
     });
     // Ensure that the target is expanded (hideShow)
     $('#minitoc a[href^="#"]').click(function() {


### PR DESCRIPTION
Hi,

The tags seem to clutter the minitoc, and it looks much cleaner without them.  See, e.g. https://alphapapa.github.io/emacs-package-dev-handbook.  So here's a PR if you'd like to merge it.  If not, that's ok too.  :)

Thanks for your work on this package.