### PR TITLE
Make timestamps in readtheorg readable

### DIFF
--- a/styles/readtheorg/css/readtheorg.css
+++ b/styles/readtheorg/css/readtheorg.css
@@ -1081,6 +1081,10 @@ h2.footnotes{
     color: navy;
 }
 
+.nav .timestamp {
+    color: inherit;
+}
+
 .inlinetask {
     background: #FFF9E3;  /* url(dialog-todo.png) no-repeat 10px 8px; */
     border: 3px solid #FFEB8E;


### PR DESCRIPTION
Timestamps in navigation bar now inherit their color instead of being navy. This makes them much more readable.

Should close #73