### PR TITLE
Fixed 2 issues on demo/example.org.

### DIFF
--- a/demo/example.org
+++ b/demo/example.org
@@ -5,13 +5,13 @@
 #+LANGUAGE:  en
 #+OPTIONS:   H:4 num:nil toc:2
 
-#+SETUPFILE: ~/src/org-html-themes/setup/theme-readtheorg.setup
+#+SETUPFILE: ../setup/theme-readtheorg.setup
 
-#+begin_html
+#+begin_export html
 <div class="right">
   <a href="https://github.com/fniessen/org-html-themes/blob/master/demo/example.org" class="fa fa-github"> Edit on GitHub</a>
 </div>
-#+end_html
+#+end_export
 
 -----
 


### PR DESCRIPTION
1). use relative path in SETUPFILE
The old approach only worked when the git repo was checked out to the same filepath.

2). use `#+begin_export html` block to replace `#+begin_html` block.
`#+begin_html` doesn't work in newer version of org-mode.