### PR TITLE
Added a nice white color for the table-of-contents item

### DIFF
--- a/styles/readtheorg/css/readtheorg.css
+++ b/styles/readtheorg/css/readtheorg.css
@@ -767,6 +767,7 @@ hr{
 }
 
 #table-of-contents a:hover{
+	color: #ffffff !important;
     background-color:#4e4a4a;
     cursor:pointer}
 


### PR DESCRIPTION
When hovering over an item in the table of contents, the default color
of text is not very visible with the #4e4a4a background color. This
fixes the issue for me.

![2020-05-31-204945_1366x768_scrot](https://user-images.githubusercontent.com/48376475/83355695-d8ffb700-a380-11ea-9e5f-3ddfafb6ab15.png)
