### PR TITLE
Removed background so the blob goes away

### DIFF
--- a/styles/readtheorg/css/readtheorg.css
+++ b/styles/readtheorg/css/readtheorg.css
@@ -428,7 +428,6 @@ table tr:nth-child(2n) td{
     }
 
     #toggle-sidebar {
-        background-color: #2980B9;
         display: block;
         margin-bottom: 1.6em;
         padding: 0.6em;


### PR DESCRIPTION
Remove the background color for #toggle-sidebar element because on
smaller screens the toggle div looks aweful, like some blob that was
misplaced.

### Before
![Sun 31 May 2020 09:02:36 PM +0545](https://user-images.githubusercontent.com/48376475/83356230-70b2d480-a384-11ea-9fc4-cff12f185bb3.png)

### After
![Sun 31 May 2020 09:20:38 PM +0545](https://user-images.githubusercontent.com/48376475/83356262-bff90500-a384-11ea-9e2b-ef653e428281.png)
