### PR TITLE
Update README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -173,7 +173,7 @@ Using a theme from the [[id:79e0ed21-c3b0-4f00-bdab-29fbff9dcad4][theme gallery]
 
    or, if you *cloned or downloaded* the Org-HTML themes project -- to get no
    dependency on an Internet connection --, use a (relative or absolute) path to
-   the local "setup file" and copy the "styles" folder from the cloned folder
+   the local "setup file" and copy the "src" folder from the cloned folder
    into the same folder as the file you want to export:
 
    #+begin_src org :exports code


### PR DESCRIPTION
Please update the README.org - the `styles` folder has been renamed to `src` in https://github.com/fniessen/org-html-themes/commit/385e8a473eba2fa30e9e891dfc1e0fa3c9a7bf3d.