### PR TITLE
Exclude default style

### DIFF
--- a/org/theme-bigblow-local.setup
+++ b/org/theme-bigblow-local.setup
@@ -1,5 +1,6 @@
 # -*- mode: org; -*-
 
+#+OPTIONS: html-style:nil
 #+HTML_HEAD: <link rel="stylesheet" type="text/css" href="src/bigblow_theme/css/htmlize.css"/>
 #+HTML_HEAD: <link rel="stylesheet" type="text/css" href="src/bigblow_theme/css/bigblow.css"/>
 #+HTML_HEAD: <link rel="stylesheet" type="text/css" href="src/bigblow_theme/css/hideshow.css"/>

--- a/org/theme-bigblow.setup
+++ b/org/theme-bigblow.setup
@@ -1,5 +1,6 @@
 # -*- mode: org; -*-
 
+#+OPTIONS: html-style:nil
 #+HTML_HEAD: <link rel="stylesheet" type="text/css" href="https://fniessen.github.io/org-html-themes/src/bigblow_theme/css/htmlize.css"/>
 #+HTML_HEAD: <link rel="stylesheet" type="text/css" href="https://fniessen.github.io/org-html-themes/src/bigblow_theme/css/bigblow.css"/>
 #+HTML_HEAD: <link rel="stylesheet" type="text/css" href="https://fniessen.github.io/org-html-themes/src/bigblow_theme/css/hideshow.css"/>

--- a/org/theme-readtheorg-local.setup
+++ b/org/theme-readtheorg-local.setup
@@ -1,5 +1,6 @@
 # -*- mode: org; -*-
 
+#+OPTIONS: html-style:nil
 #+HTML_HEAD: <link rel="stylesheet" type="text/css" href="src/readtheorg_theme/css/htmlize.css"/>
 #+HTML_HEAD: <link rel="stylesheet" type="text/css" href="src/readtheorg_theme/css/readtheorg.css"/>
 

--- a/org/theme-readtheorg.setup
+++ b/org/theme-readtheorg.setup
@@ -1,5 +1,6 @@
 # -*- mode: org; -*-
 
+#+OPTIONS: html-style:nil
 #+HTML_HEAD: <link rel="stylesheet" type="text/css" href="https://fniessen.github.io/org-html-themes/src/readtheorg_theme/css/htmlize.css"/>
 #+HTML_HEAD: <link rel="stylesheet" type="text/css" href="https://fniessen.github.io/org-html-themes/src/readtheorg_theme/css/readtheorg.css"/>
 


### PR DESCRIPTION
This fixes some of the formatting problems from #71, specifically the zero width character shown in the images below:

# Bigblow before:
![2022-05-09_15-10](https://user-images.githubusercontent.com/8166212/167481656-4926ad70-a3da-4be0-8d2f-fa86008340e0.png)

# Bigblow after:
![2022-05-09_15-11](https://user-images.githubusercontent.com/8166212/167481663-ff2b4be2-9c56-4e9b-8cd0-54c1c7a90aea.png)

# ReadTheOrg before:
![2022-05-09_15-12](https://user-images.githubusercontent.com/8166212/167481669-d7d3c3c2-3411-439e-96b8-1b128fb3ee65.png)

# ReadTheOrg after:
![2022-05-09_15-13](https://user-images.githubusercontent.com/8166212/167481684-7b8fa227-2f8e-4075-bc77-559cf0707405.png)

As for the other issues:
- The overflow issue occurs when the header/tag is too long. 
- I did not investigate the rendering of the special boxes (important, note, flagged, etc).


The reasoning behind this change is this docstring in `org-html-style-default`:
> "The default style specification for exported HTML files.
You can use `org-html-head` and `org-html-head-extra` to add to
this style.  If you don't want to include this default style,
customize `org-html-head-include-default-style'."