### PR TITLE
Fix rendering for special tags

### DIFF
--- a/src/readtheorg_theme/css/readtheorg.css
+++ b/src/readtheorg_theme/css/readtheorg.css
@@ -578,13 +578,6 @@ a .fa,a #content .admonition-title,#content a .admonition-title{
 .nav #content .admonition-title,#content .nav .admonition-title,.nav .icon{
     display:inline}
 
-.wy-alert,#content .note,#content .attention,#content .caution,#content .danger,#content .error,#content .hint,#content .important,#content .tip,#content .warning,#content .seealso,#content .admonitiontodo{
-    padding:12px;
-    line-height:24px;
-    margin-bottom:24px;
-    /* background:#e7f2fa; */
-}
-
 .wy-alert-title,#content .admonition-title{
     color:#fff;
     font-weight:bold;
@@ -595,10 +588,19 @@ a .fa,a #content .admonition-title,#content a .admonition-title{
     padding:6px 12px;
     margin-bottom:0px}
 
-#content .danger,#content .error{
+.admonition-title + div{
+    padding: 12px;
+    margin-bottom: 24px;
+}
+
+.admonition-title + div > p{
+    margin: 0;
+}
+
+.danger + div, .error + div, #content .danger,#content .error{
     background:#fdf3f2}
 
-.wy-alert.wy-alert-warning,#content .wy-alert-warning.note,#content .attention,#content .caution,#content .wy-alert-warning.danger,#content .wy-alert-warning.error,#content .wy-alert-warning.hint,#content .wy-alert-warning.important,#content .wy-alert-warning.tip,#content .warning,#content .wy-alert-warning.seealso,#content .admonitiontodo{
+.wy-alert.wy-alert-warning,#content .wy-alert-warning.note, #content .attention,#content .caution, #content .warning, #content .admonitiontodo, .attention + div, .caution + div, .warning + div, #content .wy-alert-warning.danger,#content .wy-alert-warning.error, #content .wy-alert-warning.hint,#content .wy-alert-warning.important,#content .wy-alert-warning.tip,#content .wy-alert-warning.seealso{
     background:#ffedcc}
 
 #content .admonition-title.note:before, #content .admonition-title.seealso:before,
@@ -610,17 +612,15 @@ a .fa,a #content .admonition-title,#content a .admonition-title{
     font-family:FontAwesome;
     content: "";}
 
-#content .note,#content .seealso{
-    background:#e7f2fa}
-
-.wy-alert p:last-child,#content .note p:last-child,#content .attention p:last-child,#content .caution p:last-child,#content .danger p:last-child,#content .error p:last-child,#content .hint p:last-child,#content .important p:last-child,#content .tip p:last-child,#content .warning p:last-child,#content .seealso p:last-child,#content .admonitiontodo p:last-child{
-    margin-bottom:0}
+.seealso + div, .note + div, #content .note,#content .seealso{
+    background:#e7f2fa;
+}
 
 #content .admonition-title.tip,#content .admonition-title.important,#content .admonition-title.hint{
     line-height: 1;
     background:#1abc9c}
 
-#content .important,#content .tip,#content .hint{
+.important + div, .tip + div, .hint + div, #content .important, #content .tip, #content .hint{
     background:#dbfaf4}
 
 #content .admonition-title.note,#content .admonition-title.seealso{

--- a/src/readtheorg_theme/js/readtheorg.js
+++ b/src/readtheorg_theme/js/readtheorg.js
@@ -19,16 +19,22 @@ $( document ).ready(function() {
 });
 
 $(function() {
-    $('.note').before("<p class='admonition-title note'>Note</p>");
-    $('.seealso').before("<p class='admonition-title seealso'>See also</p>");
-    $('.warning').before("<p class='admonition-title warning'>Warning</p>");
-    $('.caution').before("<p class='admonition-title caution'>Caution</p>");
-    $('.attention').before("<p class='admonition-title attention'>Attention</p>");
-    $('.tip').before("<p class='admonition-title tip'>Tip</p>");
-    $('.important').before("<p class='admonition-title important'>Important</p>");
-    $('.hint').before("<p class='admonition-title hint'>Hint</p>");
-    $('.error').before("<p class='admonition-title error'>Error</p>");
-    $('.danger').before("<p class='admonition-title danger'>Danger</p>");
+    function replace_admonition (tag, readable) {
+        $(`.${tag}:not(#table-of-contents *)`)
+            .parent().parent().replaceWith(function() {
+                return `<p id='${this.id}' class='admonition-title ${tag}'>${readable}</p>`
+            });
+    }
+    replace_admonition('note', 'Note');
+    replace_admonition('seealso', 'See also');
+    replace_admonition('warning', 'Warning');
+    replace_admonition('caution', 'Caution');
+    replace_admonition('attention', 'Attention');
+    replace_admonition('tip', 'Tip');
+    replace_admonition('important', 'Important');
+    replace_admonition('hint', 'Hint');
+    replace_admonition('error', 'Error');
+    replace_admonition('danger', 'Danger');
 });
 
 $( document ).ready(function() {

--- a/src/readtheorg_theme/readtheorg.org
+++ b/src/readtheorg_theme/readtheorg.org
@@ -726,13 +726,6 @@ a .fa,a #content .admonition-title,#content a .admonition-title{
 .nav #content .admonition-title,#content .nav .admonition-title,.nav .icon{
     display:inline}
 
-.wy-alert,#content .note,#content .attention,#content .caution,#content .danger,#content .error,#content .hint,#content .important,#content .tip,#content .warning,#content .seealso,#content .admonitiontodo{
-    padding:12px;
-    line-height:24px;
-    margin-bottom:24px;
-    /* background:#e7f2fa; */
-}
-
 .wy-alert-title,#content .admonition-title{
     color:#fff;
     font-weight:bold;
@@ -743,10 +736,19 @@ a .fa,a #content .admonition-title,#content a .admonition-title{
     padding:6px 12px;
     margin-bottom:0px}
 
-#content .danger,#content .error{
+.admonition-title + div{
+    padding: 12px;
+    margin-bottom: 24px;
+}
+
+.admonition-title + div > p{
+    margin: 0;
+}
+
+.danger + div, .error + div, #content .danger,#content .error{
     background:#fdf3f2}
 
-.wy-alert.wy-alert-warning,#content .wy-alert-warning.note,#content .attention,#content .caution,#content .wy-alert-warning.danger,#content .wy-alert-warning.error,#content .wy-alert-warning.hint,#content .wy-alert-warning.important,#content .wy-alert-warning.tip,#content .warning,#content .wy-alert-warning.seealso,#content .admonitiontodo{
+.wy-alert.wy-alert-warning,#content .wy-alert-warning.note, #content .attention,#content .caution, #content .warning, #content .admonitiontodo, .attention + div, .caution + div, .warning + div, #content .wy-alert-warning.danger,#content .wy-alert-warning.error, #content .wy-alert-warning.hint,#content .wy-alert-warning.important,#content .wy-alert-warning.tip,#content .wy-alert-warning.seealso{
     background:#ffedcc}
 
 #content .admonition-title.note:before, #content .admonition-title.seealso:before,
@@ -758,17 +760,15 @@ a .fa,a #content .admonition-title,#content a .admonition-title{
     font-family:FontAwesome;
     content: "";}
 
-#content .note,#content .seealso{
-    background:#e7f2fa}
-
-.wy-alert p:last-child,#content .note p:last-child,#content .attention p:last-child,#content .caution p:last-child,#content .danger p:last-child,#content .error p:last-child,#content .hint p:last-child,#content .important p:last-child,#content .tip p:last-child,#content .warning p:last-child,#content .seealso p:last-child,#content .admonitiontodo p:last-child{
-    margin-bottom:0}
+.seealso + div, .note + div, #content .note,#content .seealso{
+    background:#e7f2fa;
+}
 
 #content .admonition-title.tip,#content .admonition-title.important,#content .admonition-title.hint{
     line-height: 1;
     background:#1abc9c}
 
-#content .important,#content .tip,#content .hint{
+.important + div, .tip + div, .hint + div, #content .important, #content .tip, #content .hint{
     background:#dbfaf4}
 
 #content .admonition-title.note,#content .admonition-title.seealso{
@@ -1493,16 +1493,22 @@ $( document ).ready(function() {
 });
 
 $(function() {
-    $('.note').before("<p class='admonition-title note'>Note</p>");
-    $('.seealso').before("<p class='admonition-title seealso'>See also</p>");
-    $('.warning').before("<p class='admonition-title warning'>Warning</p>");
-    $('.caution').before("<p class='admonition-title caution'>Caution</p>");
-    $('.attention').before("<p class='admonition-title attention'>Attention</p>");
-    $('.tip').before("<p class='admonition-title tip'>Tip</p>");
-    $('.important').before("<p class='admonition-title important'>Important</p>");
-    $('.hint').before("<p class='admonition-title hint'>Hint</p>");
-    $('.error').before("<p class='admonition-title error'>Error</p>");
-    $('.danger').before("<p class='admonition-title danger'>Danger</p>");
+    function replace_admonition (tag, readable) {
+        $(`.${tag}:not(#table-of-contents *)`)
+            .parent().parent().replaceWith(function() {
+                return `<p id='${this.id}' class='admonition-title ${tag}'>${readable}</p>`
+            });
+    }
+    replace_admonition('note', 'Note');
+    replace_admonition('seealso', 'See also');
+    replace_admonition('warning', 'Warning');
+    replace_admonition('caution', 'Caution');
+    replace_admonition('attention', 'Attention');
+    replace_admonition('tip', 'Tip');
+    replace_admonition('important', 'Important');
+    replace_admonition('hint', 'Hint');
+    replace_admonition('error', 'Error');
+    replace_admonition('danger', 'Danger');
 });
 
 $( document ).ready(function() {


### PR DESCRIPTION
Another fix for #71

The following examples use this file as a source:

```
#+TITLE: Test
#+SETUPFILE: org-html-themes/org/theme-readtheorg-local.setup
* Example :tag:
** NoteHeader :note:
This is some content.
** WarningHeader :warning:
This is some content.
** TipHeader :tip:
This is some content.
** ErrorHeader :error:
This is some content.
* Full Example :tag:
** NoteHeader :note:
This is some content.
** SeealsoHeader :seealso:
This is some content.
** WarningHeader :warning:
This is some content.
** CautionHeader :caution:
This is some content.
** AttentionHeader :attention:
This is some content.
** TipHeader :tip:
This is some content.
** ImportantHeader :important:
This is some content.
** HintHeader :hint:
This is some content.
** ErrorHeader :error:
This is some content.
** DangerHeader :danger:
This is some content.
** NotspecialHeader :notspecial:
This is some content.
```

# Before
![before-js](https://user-images.githubusercontent.com/8166212/167518305-c0f4d823-bd00-4df2-bc9b-01e72898108b.png)

# After
![after-js](https://user-images.githubusercontent.com/8166212/167518315-2c762543-958f-4355-9437-2d71808b578e.png)

# Before (No JS)
![before-nojs](https://user-images.githubusercontent.com/8166212/167518325-08de1af9-4792-4df3-80e9-8014a17a00bf.png)

# After (No JS)
![after-nojs](https://user-images.githubusercontent.com/8166212/167518330-ad15c2b9-a002-45cf-9332-c98019a05368.png)

