### PR TITLE
Prevent "UP | HOME" links from being hidden by TOC

### DIFF
--- a/src/readtheorg_theme/css/readtheorg.css
+++ b/src/readtheorg_theme/css/readtheorg.css
@@ -1135,3 +1135,8 @@ h2.footnotes{
     padding: 9px 12px;
     margin-bottom: 24px;
     font-family:"Roboto Slab","ff-tisa-web-pro","Georgia",Arial,sans-serif}
+
+#org-div-home-and-up { 
+    text-align: right;
+    padding-right: 10pt;
+}


### PR DESCRIPTION
I finally created a pull request to fix the issue I posted (#150).

This change in the CSS prevents the HOME and UP links from being hidden when using ReadTheOrg theme.

I tested this change in the CSS and verified that it works by adding the following to my Org files:

```
#+OPTIONS: html-style:nil
#+HTML_HEAD: <link rel="stylesheet" type="text/css" href="https://tfree87.github.io/org-html-themes/src/readtheorg_theme/css/htmlize.css"/>
#+HTML_HEAD: <link rel="stylesheet" type="text/css" href="https://tfree87.github.io/org-html-themes/src/readtheorg_theme/css/readtheorg.css"/>

#+HTML_HEAD: <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
#+HTML_HEAD: <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
#+HTML_HEAD: <script type="text/javascript" src="https://fniessen.github.io/org-html-themes/src/lib/js/jquery.stickytableheaders.min.js"></script>
#+HTML_HEAD: <script type="text/javascript" src="https://fniessen.github.io/org-html-themes/src/readtheorg_theme/js/readtheorg.js"></script>
```
The above code produced the expected result.

Thanks for all your work on this neat project!