### PR TITLE
Fixes #143

### DIFF
--- a/src/readtheorg_theme/css/readtheorg.css
+++ b/src/readtheorg_theme/css/readtheorg.css
@@ -47,7 +47,6 @@ html{
     -webkit-text-size-adjust:100%;
     font-size:100%;
     height:100%;
-    overflow-x:hidden;
 }
 
 body{
@@ -57,7 +56,6 @@ body{
     font-weight:normal;
     margin:0;
     min-height:100%;
-    overflow-x:hidden;
 }
 
 #content{

--- a/src/readtheorg_theme/css/readtheorg.css
+++ b/src/readtheorg_theme/css/readtheorg.css
@@ -62,7 +62,6 @@ body{
 
 #content{
     background:#fcfcfc;
-    height:100%;
     margin-left:300px;
     /* margin:auto; */
     max-width:800px;

--- a/src/readtheorg_theme/readtheorg.org
+++ b/src/readtheorg_theme/readtheorg.org
@@ -93,7 +93,6 @@ body{
 
 #content{
     background:#fcfcfc;
-    height:100%;
     margin-left:300px;
     /* margin:auto; */
     max-width:800px;

--- a/src/readtheorg_theme/readtheorg.org
+++ b/src/readtheorg_theme/readtheorg.org
@@ -78,7 +78,6 @@ html{
     -webkit-text-size-adjust:100%;
     font-size:100%;
     height:100%;
-    overflow-x:hidden;
 }
 
 body{
@@ -88,7 +87,6 @@ body{
     font-weight:normal;
     margin:0;
     min-height:100%;
-    overflow-x:hidden;
 }
 
 #content{


### PR DESCRIPTION
Fixes issue #143 in the ReadTheOrg theme where the `#content` div didn't extend for the entire page and the TOC didn't fold/unfold when scrolling.
Full explanation with an example is provided on the issue page.