### PR TITLE
Update readtheorg.css

### DIFF
--- a/src/readtheorg_theme/css/readtheorg.css
+++ b/src/readtheorg_theme/css/readtheorg.css
@@ -339,6 +339,7 @@ pre.src{
     line-height: 1.5;
     margin-bottom:24px;
     padding:12px;
+    overflow: auto;
 }
 
 table{


### PR DESCRIPTION
Hello there.

The .example class, used to export code block results is overflowing and breaking this cool theme, as in both Safari (15.6) and Chrome (103).

![image](https://user-images.githubusercontent.com/16169950/182052280-8bf2e69a-f134-4d74-8d64-7dde6daf2a6d.png)

This PR sets auto-overflow when needed by `.example` class:

Needed:
![image](https://user-images.githubusercontent.com/16169950/182052328-92227c73-09ae-4a46-b993-9ee3cb1924e0.png)

Not needed:
![image](https://user-images.githubusercontent.com/16169950/182052357-21aa7c65-5187-410f-8c8b-800025ab246c.png)
