### PR TITLE
Fix call to next TODO review instead of quit on click

### DIFF
--- a/src/bigblow_theme/js/hideshow.js
+++ b/src/bigblow_theme/js/hideshow.js
@@ -311,7 +311,7 @@ function hsAddReviewingPanels() {
                             + 'Shortcuts: '
                             + '<span class="hsReviewButton" onclick="hsReviewTaskNext()">r (next)</span> - '
                             + '<span class="hsReviewButton" onclick="hsReviewTaskPrev()">R (previous)</span><br>'
-                            + '<span class="hsReviewButton" onclick="hsReviewTaskPrev()">q (quit)</span>'
+                            + '<span class="hsReviewButton" onclick="hsReviewTaskQuit()">q (quit)</span>'
                             + '</div>');
         }
         else {
@@ -320,7 +320,7 @@ function hsAddReviewingPanels() {
                             + 'Shortcuts: '
                             + '<span class="hsReviewButton" onclick="hsReviewTaskNext()">r (next)</span> - '
                             + '<span class="hsReviewButton" onclick="hsReviewTaskPrev()">R (previous)</span><br>'
-                            + '<span class="hsReviewButton" onclick="hsReviewTaskPrev()">q (quit)</span>'
+                            + '<span class="hsReviewButton" onclick="hsReviewTaskQuit()">q (quit)</span>'
                             + '</div>');
         }
     });


### PR DESCRIPTION
Make clicking on "quit" the same as pressing 'q'.

Probably a copy-paste error initially ?