### PR TITLE
Fix admonitions invoked with #+begin_

### DIFF
--- a/src/readtheorg_theme/js/readtheorg.js
+++ b/src/readtheorg_theme/js/readtheorg.js
@@ -20,10 +20,9 @@ $( document ).ready(function() {
 
 $(function() {
     function replace_admonition (tag, readable) {
-        $(`.${tag}:not(#table-of-contents *)`)
-            .parent().parent().replaceWith(function() {
-                return `<p id='${this.id}' class='admonition-title ${tag}'>${readable}</p>`
-            });
+        $(`span.${tag}:not(#table-of-contents *)`) .parent().parent()
+            .replaceWith(`<p id='${this.id}' class='admonition-title ${tag}'>${readable}</p>`);
+        $(`div.${tag}`).before(`<p class='admonition-title ${tag}'>${readable}</p>`)
     }
     replace_admonition('note', 'Note');
     replace_admonition('seealso', 'See also');

--- a/src/readtheorg_theme/readtheorg.org
+++ b/src/readtheorg_theme/readtheorg.org
@@ -1491,10 +1491,9 @@ $( document ).ready(function() {
 
 $(function() {
     function replace_admonition (tag, readable) {
-        $(`.${tag}:not(#table-of-contents *)`)
-            .parent().parent().replaceWith(function() {
-                return `<p id='${this.id}' class='admonition-title ${tag}'>${readable}</p>`
-            });
+        $(`span.${tag}:not(#table-of-contents *)`) .parent().parent()
+            .replaceWith(`<p id='${this.id}' class='admonition-title ${tag}'>${readable}</p>`);
+        $(`div.${tag}`).before(`<p class='admonition-title ${tag}'>${readable}</p>`)
     }
     replace_admonition('note', 'Note');
     replace_admonition('seealso', 'See also');


### PR DESCRIPTION
My previous pull request only works when the special boxes are invoked with tags. When using `#+begin_note` for example, the content is lost. These changes should work with both ways to create the special boxes.

## Before:
![image](https://user-images.githubusercontent.com/8166212/187272493-d3ab2e70-5e33-488d-9c68-230d050eb29c.png)


## After:
![image](https://user-images.githubusercontent.com/8166212/187272382-55fa8418-0e5f-45d7-a69e-b1d5f0fd8f96.png)


## Source file
```org
#+title: Test
#+SETUPFILE: org/theme-readtheorg-local.setup
* This is a test
I want to add some content before a note.
#+begin_note
To insert a note in the middle of headings, I use ~#+begin_note~ and ~#+end_note~
#+end_note
In addition to some content after the note
** Note created with tags :note:
This is a note created by adding ~:note:~ to a heading. I want it to be in the table of contents.
```