### PR TITLE
Add search bar to read-the-org theme

### DIFF
--- a/org/theme-readtheorg-local.setup
+++ b/org/theme-readtheorg-local.setup
@@ -3,8 +3,10 @@
 #+OPTIONS: html-style:nil
 #+HTML_HEAD: <link rel="stylesheet" type="text/css" href="src/readtheorg_theme/css/htmlize.css"/>
 #+HTML_HEAD: <link rel="stylesheet" type="text/css" href="src/readtheorg_theme/css/readtheorg.css"/>
+#+HTML_HEAD: <link rel="stylesheet" type="text/css" href="src/readtheorg_theme/css/search.css"/>
 
 #+HTML_HEAD: <script type="text/javascript" src="src/lib/js/jquery.min.js"></script>
 #+HTML_HEAD: <script type="text/javascript" src="src/lib/js/bootstrap.min.js"></script>
 #+HTML_HEAD: <script type="text/javascript" src="src/lib/js/jquery.stickytableheaders.min.js"></script>
 #+HTML_HEAD: <script type="text/javascript" src="src/readtheorg_theme/js/readtheorg.js"></script>
+#+HTML_HEAD: <script type="text/javascript" src="src/readtheorg_theme/js/search.js"></script>

--- a/org/theme-readtheorg-local.setup
+++ b/org/theme-readtheorg-local.setup
@@ -8,5 +8,21 @@
 #+HTML_HEAD: <script type="text/javascript" src="src/lib/js/jquery.min.js"></script>
 #+HTML_HEAD: <script type="text/javascript" src="src/lib/js/bootstrap.min.js"></script>
 #+HTML_HEAD: <script type="text/javascript" src="src/lib/js/jquery.stickytableheaders.min.js"></script>
-#+HTML_HEAD: <script type="text/javascript" src="src/readtheorg_theme/js/readtheorg.js"></script>
 #+HTML_HEAD: <script type="text/javascript" src="src/readtheorg_theme/js/search.js"></script>
+#+HTML_HEAD: <script type="text/javascript" src="src/readtheorg_theme/js/readtheorg.js"></script>
+
+#+MACRO: enable-search #+HTML_HEAD: <script type="text/javascript">enableSearch();</script>
+#+MACRO: disable-search #+HTML_HEAD: <script type="text/javascript">disableSearch();</script>
+#+MACRO: set-search-limit #+HTML_HEAD: <script type="text/javascript">setSearchLimit($1);</script>
+
+* Search Configuration (v1.12) :noexport:
+Usage: Optionally place these macros after including this file, before your content.
+- {{{enable-search}}}: :: enable search bar (default)
+- {{{disable-search}}}: :: disable search bar
+- {{{set-search-limit(N)}}}: :: Limit results to N (default: 0 for no limit)
+
+Example:
+#+BEGIN_SRC org
+{{{enable-search}}}
+{{{set-search-limit(10)}}}
+#+END_SRC

--- a/org/theme-readtheorg.setup
+++ b/org/theme-readtheorg.setup
@@ -3,8 +3,10 @@
 #+OPTIONS: html-style:nil
 #+HTML_HEAD: <link rel="stylesheet" type="text/css" href="https://fniessen.github.io/org-html-themes/src/readtheorg_theme/css/htmlize.css"/>
 #+HTML_HEAD: <link rel="stylesheet" type="text/css" href="https://fniessen.github.io/org-html-themes/src/readtheorg_theme/css/readtheorg.css"/>
+#+HTML_HEAD: <link rel="stylesheet" type="text/css" href="src/readtheorg_theme/css/search.css"/>
 
 #+HTML_HEAD: <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 #+HTML_HEAD: <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
 #+HTML_HEAD: <script type="text/javascript" src="https://fniessen.github.io/org-html-themes/src/lib/js/jquery.stickytableheaders.min.js"></script>
 #+HTML_HEAD: <script type="text/javascript" src="https://fniessen.github.io/org-html-themes/src/readtheorg_theme/js/readtheorg.js"></script>
+#+HTML_HEAD: <script type="text/javascript" src="src/readtheorg_theme/js/search.js"></script>

--- a/org/theme-readtheorg.setup
+++ b/org/theme-readtheorg.setup
@@ -8,5 +8,21 @@
 #+HTML_HEAD: <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 #+HTML_HEAD: <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
 #+HTML_HEAD: <script type="text/javascript" src="https://fniessen.github.io/org-html-themes/src/lib/js/jquery.stickytableheaders.min.js"></script>
-#+HTML_HEAD: <script type="text/javascript" src="https://fniessen.github.io/org-html-themes/src/readtheorg_theme/js/readtheorg.js"></script>
 #+HTML_HEAD: <script type="text/javascript" src="src/readtheorg_theme/js/search.js"></script>
+#+HTML_HEAD: <script type="text/javascript" src="https://fniessen.github.io/org-html-themes/src/readtheorg_theme/js/readtheorg.js"></script>
+
+#+MACRO: enable-search #+HTML_HEAD: <script type="text/javascript">enableSearch();</script>
+#+MACRO: disable-search #+HTML_HEAD: <script type="text/javascript">disableSearch();</script>
+#+MACRO: set-search-limit #+HTML_HEAD: <script type="text/javascript">setSearchLimit($1);</script>
+
+* Search Configuration (v1.12) :noexport:
+Usage: Optionally place these macros after including this file, before your content.
+- {{{enable-search}}}: :: enable search bar (default)
+- {{{disable-search}}}: :: disable search bar
+- {{{set-search-limit(N)}}}: :: Limit results to N (default: 0 for no limit)
+
+Example:
+#+BEGIN_SRC org
+{{{enable-search}}}
+{{{set-search-limit(10)}}}
+#+END_SRC

--- a/src/readtheorg_theme/css/search.css
+++ b/src/readtheorg_theme/css/search.css
@@ -1,0 +1,38 @@
+/* -*- mode: css; -*- */
+
+/* read-the-org search styles, v1.6 */
+
+#search-container {
+  padding: 10px;
+  background-color: #343131;
+}
+#search-input {
+  width: 100%;
+  padding: 5px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 14px;
+}
+#search-results {
+  list-style-type: none;
+  padding: 0;
+  margin: 10px 0 0 0;
+  max-height: 300px;
+  overflow-y: auto;
+}
+#search-results li {
+  background-color: #2980B9;
+  color: white;
+  margin-bottom: 5px;
+  padding: 5px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+}
+#search-results li:hover {
+  background-color: #3091d1;
+}
+mark {
+  background-color: yellow;
+  color: black;
+}

--- a/src/readtheorg_theme/css/search.css
+++ b/src/readtheorg_theme/css/search.css
@@ -1,4 +1,4 @@
-/* -*- mode: css; -*- */
+/* -*- mode: css -*- */
 
 /* read-the-org search styles, v1.6 */
 
@@ -6,6 +6,7 @@
   padding: 10px;
   background-color: #343131;
 }
+
 #search-input {
   width: 100%;
   padding: 5px;
@@ -13,6 +14,7 @@
   border-radius: 4px;
   font-size: 14px;
 }
+
 #search-results {
   list-style-type: none;
   padding: 0;
@@ -20,6 +22,7 @@
   max-height: 300px;
   overflow-y: auto;
 }
+
 #search-results li {
   background-color: #2980B9;
   color: white;
@@ -29,9 +32,15 @@
   cursor: pointer;
   font-size: 14px;
 }
+
 #search-results li:hover {
   background-color: #3091d1;
 }
+
+#search-description {
+  color: #b3b3b3; /* Lighter color, matching the TOC text color in readtheorg.css */
+}
+
 mark {
   background-color: yellow;
   color: black;

--- a/src/readtheorg_theme/js/search.js
+++ b/src/readtheorg_theme/js/search.js
@@ -1,0 +1,135 @@
+// readh-the-org-search v1.5
+console.log('custom-search.js v1.6 is being loaded');
+
+$(document).ready(function() {
+  console.log('Document ready, initializing search functionality v1.5');
+
+  $('#table-of-contents').prepend(`
+    <div id="search-container">
+      <label for="search-input" class="sr-only">Search document</label>
+      <input type="text" id="search-input" placeholder="Search..." aria-describedby="search-description">
+      <div id="search-description" class="sr-only">Type to search the document. Use arrow keys to navigate results.</div>
+      <ul id="search-results" role="listbox" aria-label="Search results"></ul>
+    </div>
+  `);
+
+  const searchInput = $('#search-input');
+  const searchResults = $('#search-results');
+  const content = $('#content');
+  let searchIndex = [];
+
+  function createSearchIndex() {
+    console.log('Creating search index');
+    content.find('h1, h2, h3, h4, h5, h6, p').each(function() {
+      const element = $(this);
+      const text = element.text().trim();
+      if (text) {
+        searchIndex.push({
+          text: text.toLowerCase(),
+          element: element,
+          type: element.prop('tagName').toLowerCase()
+        });
+      }
+    });
+    console.log(`Search index created with ${searchIndex.length} items`);
+  }
+
+  createSearchIndex();
+
+  function debounce(func, wait) {
+    let timeout;
+    return function executedFunction(...args) {
+      const later = () => {
+        clearTimeout(timeout);
+        func(...args);
+      };
+      clearTimeout(timeout);
+      timeout = setTimeout(later, wait);
+    };
+  }
+
+  function highlightText(text, term) {
+    const regex = new RegExp(`(${term})`, 'gi');
+    return text.replace(regex, '<mark>$1</mark>');
+  }
+
+  function performSearch() {
+    const searchTerm = searchInput.val().toLowerCase();
+    searchResults.empty();
+
+    if (searchTerm.length < 3) {
+      searchResults.append('<li>Please enter at least 3 characters</li>');
+      return;
+    }
+
+    const matches = searchIndex.filter(item => item.text.includes(searchTerm));
+
+    if (matches.length === 0) {
+      searchResults.append('<li>No results found</li>');
+      return;
+    }
+
+    matches.slice(0, 10).forEach((match, index) => {
+      const snippet = match.text.length > 100 ? match.text.substr(0, 100) + '...' : match.text;
+      const highlightedSnippet = highlightText(snippet, searchTerm);
+      const li = $(`<li role="option" tabindex="-1">${highlightedSnippet}</li>`);
+      li.data('element', match.element);
+      searchResults.append(li);
+    });
+
+    searchResults.children().first().attr('tabindex', '0');
+  }
+
+  const debouncedSearch = debounce(performSearch, 300);
+
+  searchInput.on('input', debouncedSearch);
+
+  searchResults.on('click keypress', 'li', function(e) {
+    if (e.type === 'click' || (e.type === 'keypress' && e.which === 13)) {
+      const element = $(this).data('element');
+      const searchTerm = searchInput.val();
+
+      // Remove existing highlights
+      content.find('mark').each(function() {
+        const text = $(this).text();
+        $(this).replaceWith(text);
+      });
+
+      // Highlight all occurrences
+      element.html(highlightText(element.text(), searchTerm));
+
+      // Scroll to element
+      $('html, body').animate({
+        scrollTop: element.offset().top - 50
+      }, 500);
+
+      // Set focus to the highlighted element
+      element.attr('tabindex', '-1').focus();
+    }
+  });
+
+  // Keyboard navigation for search results
+  searchResults.on('keydown', 'li', function(e) {
+    const current = $(this);
+    let target;
+
+    switch(e.which) {
+      case 38: // Up arrow
+        target = current.prev();
+        break;
+      case 40: // Down arrow
+        target = current.next();
+        break;
+      default: return;
+    }
+
+    if (target.length > 0) {
+      current.attr('tabindex', '-1');
+      target.attr('tabindex', '0').focus();
+    }
+
+    e.preventDefault();
+  });
+
+  console.log('Search functionality v1.6 initialization complete');
+});

--- a/src/readtheorg_theme/js/search.js
+++ b/src/readtheorg_theme/js/search.js
@@ -1,8 +1,11 @@
-// readh-the-org-search v1.5
-console.log('custom-search.js v1.6 is being loaded');
+// -*- mode: js2 -*-
+
+// readh-the-org-search v1.8
+
+console.log('custom-search.js v1.8 is being loaded');
 
 $(document).ready(function() {
-  console.log('Document ready, initializing search functionality v1.5');
+  console.log('Document ready, initializing search functionality v1.8');
 
   $('#table-of-contents').prepend(`
     <div id="search-container">
@@ -15,6 +18,7 @@ $(document).ready(function() {
 
   const searchInput = $('#search-input');
   const searchResults = $('#search-results');
+  const searchDescription = $('#search-description');
   const content = $('#content');
   let searchIndex = [];
 
@@ -57,8 +61,17 @@ $(document).ready(function() {
     const searchTerm = searchInput.val().toLowerCase();
     searchResults.empty();
 
+    if (searchTerm.length === 0) {
+      searchDescription.show();
+      searchResults.hide();
+      return;
+    }
+
+    searchDescription.hide();
+    searchResults.show();
+
     if (searchTerm.length < 3) {
-      searchResults.append('<li>Please enter at least 3 characters</li>');
+      searchResults.html('<li>Please enter at least 3 characters</li>');
       return;
     }
 
@@ -131,5 +144,5 @@ $(document).ready(function() {
     e.preventDefault();
   });
 
-  console.log('Search functionality v1.6 initialization complete');
+  console.log('Search functionality v1.8 initialization complete');
 });

--- a/src/readtheorg_theme/js/search.js
+++ b/src/readtheorg_theme/js/search.js
@@ -1,11 +1,47 @@
 // -*- mode: js2 -*-
 
-// readh-the-org-search v1.8
+// read-the-org-search
 
-console.log('custom-search.js v1.8 is being loaded');
+// Configuration
+const SEARCH_VERSION = "v1.12";
+
+// Default configuration
+window.searchConfig = {
+    enableSearch: true,
+    searchResultLimit: 0
+};
+
+// Configuration function
+
+
+function enableSearch(enableSearch, searchResultLimit) {
+    window.searchConfig.enableSearch = true;
+}
+
+
+function disableSearch() {
+    window.searchConfig.enableSearch = false;
+}
+
+
+function setSearchLimit(searchResultLimit) {
+    window.searchConfig.searchResultLimit = searchResultLimit;
+}
+
+
+console.log(`custom-search.js ${SEARCH_VERSION} is being loaded`);
+
 
 $(document).ready(function() {
-  console.log('Document ready, initializing search functionality v1.8');
+  console.log(`Document ready, initializing search ${SEARCH_VERSION}`);
+
+  const ENABLE_SEARCH = window.searchConfig.enableSearch;
+  const SEARCH_RESULT_LIMIT = window.searchConfig.searchResultLimit;
+
+  if (!ENABLE_SEARCH) {
+    console.log('Search functionality is disabled');
+    return;
+  }
 
   $('#table-of-contents').prepend(`
     <div id="search-container">
@@ -82,7 +118,10 @@ $(document).ready(function() {
       return;
     }
 
-    matches.slice(0, 10).forEach((match, index) => {
+    // Apply the search result limit
+    const limitedMatches = SEARCH_RESULT_LIMIT > 0 ? matches.slice(0, SEARCH_RESULT_LIMIT) : matches;
+
+    limitedMatches.forEach((match, index) => {
       const snippet = match.text.length > 100 ? match.text.substr(0, 100) + '...' : match.text;
       const highlightedSnippet = highlightText(snippet, searchTerm);
       const li = $(`<li role="option" tabindex="-1">${highlightedSnippet}</li>`);
@@ -144,5 +183,5 @@ $(document).ready(function() {
     e.preventDefault();
   });
 
-  console.log('Search functionality v1.8 initialization complete');
+  console.log(`Search ${SEARCH_VERSION} initialization complete`);
 });


### PR DESCRIPTION
# Search bar for read-the-org theme

## Rationale

I love your read-the-org theme, and have been using it quite a bit for technical documents.  

I previously was using sphinx with read-the-docs.  I recently had a sphinx-generated document open and realized that the search bar feature was missing from read-the-org, so I added a very simple one.

## Basic functions

This implements a very simple search with keyboard navigation within the search results and highlighting of search matches in the text.

## Basic structure

The search is implemented in the search.js and search.css files, included from the theme-readtheorg*.org files.  If more appropriate, it would be simple to include them from the js, css, or readtheorg.org files.


## Notes:

1. I haven't really used the bigblow theme, so I don't know how well a search bar would fit, but this should be easy to drop in to other themes.