### PR TITLE
Add copy button functionality to code blocks

### DIFF
--- a/org/theme-readtheorg-local.setup
+++ b/org/theme-readtheorg-local.setup
@@ -3,6 +3,7 @@
 #+OPTIONS: html-style:nil
 #+HTML_HEAD: <link rel="stylesheet" type="text/css" href="src/readtheorg_theme/css/htmlize.css"/>
 #+HTML_HEAD: <link rel="stylesheet" type="text/css" href="src/readtheorg_theme/css/readtheorg.css"/>
+#+HTML_HEAD: <link rel="stylesheet" type="text/css" href="src/readtheorg_theme/css/code-copy.css"/>
 #+HTML_HEAD: <link rel="stylesheet" type="text/css" href="src/readtheorg_theme/css/search.css"/>
 
 #+HTML_HEAD: <script type="text/javascript" src="src/lib/js/jquery.min.js"></script>
@@ -10,6 +11,7 @@
 #+HTML_HEAD: <script type="text/javascript" src="src/lib/js/jquery.stickytableheaders.min.js"></script>
 #+HTML_HEAD: <script type="text/javascript" src="src/readtheorg_theme/js/search.js"></script>
 #+HTML_HEAD: <script type="text/javascript" src="src/readtheorg_theme/js/readtheorg.js"></script>
+#+HTML_HEAD: <script type="text/javascript" src="src/readtheorg_theme/js/code-copy.js"></script>
 
 #+MACRO: enable-search #+HTML_HEAD: <script type="text/javascript">enableSearch();</script>
 #+MACRO: disable-search #+HTML_HEAD: <script type="text/javascript">disableSearch();</script>

--- a/org/theme-readtheorg.setup
+++ b/org/theme-readtheorg.setup
@@ -3,6 +3,7 @@
 #+OPTIONS: html-style:nil
 #+HTML_HEAD: <link rel="stylesheet" type="text/css" href="https://fniessen.github.io/org-html-themes/src/readtheorg_theme/css/htmlize.css"/>
 #+HTML_HEAD: <link rel="stylesheet" type="text/css" href="https://fniessen.github.io/org-html-themes/src/readtheorg_theme/css/readtheorg.css"/>
+#+HTML_HEAD: <link rel="stylesheet" type="text/css" href="https://fniessen.github.io/org-html-themes/src/readtheorg_theme/css/code-copy.css"/>
 #+HTML_HEAD: <link rel="stylesheet" type="text/css" href="src/readtheorg_theme/css/search.css"/>
 
 #+HTML_HEAD: <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
@@ -10,6 +11,7 @@
 #+HTML_HEAD: <script type="text/javascript" src="https://fniessen.github.io/org-html-themes/src/lib/js/jquery.stickytableheaders.min.js"></script>
 #+HTML_HEAD: <script type="text/javascript" src="https://fniessen.github.io/org-html-themes/src/readtheorg_theme/js/search.js"></script>
 #+HTML_HEAD: <script type="text/javascript" src="https://fniessen.github.io/org-html-themes/src/readtheorg_theme/js/readtheorg.js"></script>
+#+HTML_HEAD: <script type="text/javascript" src="https://fniessen.github.io/org-html-themes/src/readtheorg_theme/js/code-copy.js"></script>
 
 #+MACRO: enable-search #+HTML_HEAD: <script type="text/javascript">enableSearch();</script>
 #+MACRO: disable-search #+HTML_HEAD: <script type="text/javascript">disableSearch();</script>

--- a/src/readtheorg_theme/css/code-copy.css
+++ b/src/readtheorg_theme/css/code-copy.css
@@ -1,0 +1,88 @@
+/**
+ * Code Copy Button Styles
+ * Styling for copy buttons on code blocks
+ */
+
+/* Container positioning */
+.org-src-container {
+    position: relative;
+}
+
+pre.src {
+    position: relative;
+    padding-top: 30px; /* Make room for the button */
+}
+
+/* Copy button styling */
+.copy-code-button {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    padding: 4px 10px;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1.4;
+    color: #333;
+    background-color: #f5f5f5;
+    border: 1px solid #d1d1d1;
+    border-radius: 3px;
+    cursor: pointer;
+    opacity: 0.8;
+    transition: all 0.2s ease;
+    z-index: 10;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+/* Hover state */
+.copy-code-button:hover {
+    opacity: 1;
+    background-color: #e8e8e8;
+    border-color: #b1b1b1;
+    transform: translateY(-1px);
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+/* Active/click state */
+.copy-code-button:active {
+    transform: translateY(0);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+}
+
+/* Success state */
+.copy-code-button.copied {
+    background-color: #28a745;
+    color: white;
+    border-color: #28a745;
+}
+
+.copy-code-button.copied:hover {
+    background-color: #218838;
+    border-color: #1e7e34;
+}
+
+/* Failed state */
+.copy-code-button.failed {
+    background-color: #dc3545;
+    color: white;
+    border-color: #dc3545;
+}
+
+/* Focus state for accessibility */
+.copy-code-button:focus {
+    outline: 2px solid #007bff;
+    outline-offset: 2px;
+}
+
+/* Dark theme support (if applicable) */
+@media (prefers-color-scheme: dark) {
+    .copy-code-button {
+        color: #e0e0e0;
+        background-color: #3a3a3a;
+        border-color: #555;
+    }
+    
+    .copy-code-button:hover {
+        background-color: #4a4a4a;
+        border-color: #666;
+    }
+}

--- a/src/readtheorg_theme/js/code-copy.js
+++ b/src/readtheorg_theme/js/code-copy.js
@@ -1,0 +1,83 @@
+/**
+ * Code Copy Button Functionality
+ * Adds copy buttons to code blocks for easy clipboard copying
+ */
+
+document.addEventListener('DOMContentLoaded', function() {
+    // Add copy button to all code blocks
+    const codeBlocks = document.querySelectorAll('pre.src, .org-src-container pre');
+    
+    codeBlocks.forEach(function(codeBlock) {
+        // Create copy button
+        const copyButton = document.createElement('button');
+        copyButton.className = 'copy-code-button';
+        copyButton.textContent = 'Copy';
+        copyButton.setAttribute('aria-label', 'Copy code to clipboard');
+        
+        // Position the button
+        const container = codeBlock.closest('.org-src-container') || codeBlock.parentElement;
+        container.style.position = 'relative';
+        container.appendChild(copyButton);
+        
+        // Add click handler
+        copyButton.addEventListener('click', function() {
+            // Get the code text
+            let codeText = codeBlock.textContent || codeBlock.innerText;
+            
+            // Remove line numbers if present (format: "  1: " or " 123: ")
+            const lines = codeText.split('\n');
+            const cleanedLines = lines.map(line => {
+                return line.replace(/^\s*\d+:\s/, '');
+            });
+            codeText = cleanedLines.join('\n').trim();
+            
+            // Copy to clipboard
+            if (navigator.clipboard && window.isSecureContext) {
+                // Use modern clipboard API
+                navigator.clipboard.writeText(codeText).then(function() {
+                    showCopyFeedback(copyButton, true);
+                }).catch(function(err) {
+                    console.error('Failed to copy: ', err);
+                    fallbackCopy(codeText, copyButton);
+                });
+            } else {
+                // Fallback for older browsers or non-HTTPS
+                fallbackCopy(codeText, copyButton);
+            }
+        });
+    });
+    
+    // Show copy feedback
+    function showCopyFeedback(button, success) {
+        const originalText = button.textContent;
+        button.textContent = success ? 'Copied!' : 'Failed';
+        button.classList.add(success ? 'copied' : 'failed');
+        
+        setTimeout(function() {
+            button.textContent = originalText;
+            button.classList.remove('copied', 'failed');
+        }, 2000);
+    }
+    
+    // Fallback copy method using textarea
+    function fallbackCopy(text, button) {
+        const textArea = document.createElement('textarea');
+        textArea.value = text;
+        textArea.style.position = 'fixed';
+        textArea.style.left = '-999999px';
+        textArea.style.top = '-999999px';
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
+        
+        try {
+            const successful = document.execCommand('copy');
+            showCopyFeedback(button, successful);
+        } catch (err) {
+            console.error('Fallback copy failed: ', err);
+            showCopyFeedback(button, false);
+        }
+        
+        document.body.removeChild(textArea);
+    }
+});


### PR DESCRIPTION
## Summary

This PR adds a convenient copy button to all code blocks in the ReadTheOrg theme, making it easier for users to copy code snippets to their clipboard.

## Features

- **Automatic copy button insertion**: A copy button is automatically added to all code blocks when the page loads
- **Smart line number removal**: When copying, line numbers are automatically stripped from the text for clean pasting
- **Visual feedback**: The button shows "Copied!" confirmation when successful
- **Cross-browser compatibility**: Uses modern Clipboard API with automatic fallback to older methods for broader browser support
- **Accessible design**: Includes proper ARIA labels and keyboard focus states
- **Non-intrusive styling**: The button appears subtly in the top-right corner of code blocks

## Implementation Details

### New Files Added:
- `src/readtheorg_theme/js/code-copy.js` - JavaScript functionality for copy button
- `src/readtheorg_theme/css/code-copy.css` - Styling for the copy button

### Modified Files:
- `org/theme-readtheorg.setup` - Added references to new CSS and JS files
- `org/theme-readtheorg-local.setup` - Added references for local development

### Technical Approach:
1. The JavaScript runs after DOM content loads
2. It finds all code blocks (`pre.src` and `.org-src-container pre`)
3. For each block, it creates a styled button element
4. Click handler extracts text, removes line numbers, and copies to clipboard
5. Provides visual feedback and handles both success and failure cases

## Testing

Tested on:
- Modern browsers (Chrome, Firefox, Safari, Edge)
- Both HTTPS and HTTP contexts
- Code blocks with and without line numbers
- Various code block sizes and languages

## Backward Compatibility

This change is fully backward compatible:
- No existing functionality is modified
- The feature gracefully degrades if JavaScript is disabled
- Existing themes and configurations continue to work unchanged

## Screenshots

The copy button appears in the top-right corner of code blocks and shows "Copied!" feedback when clicked.

Thank you for considering this enhancement to the org-html-themes project!