### PR TITLE
Fix copy button positioning for code blocks with captions

### DIFF
--- a/src/bigblow_theme/css/bigblow.css
+++ b/src/bigblow_theme/css/bigblow.css
@@ -738,6 +738,10 @@ p.verse {
     position: relative;
 }
 
+.org-src-container pre.src {
+    position: relative;
+}
+
 .snippet-copy-to-clipboard {
     display: none;
     position: absolute;

--- a/src/bigblow_theme/js/bigblow.js
+++ b/src/bigblow_theme/js/bigblow.js
@@ -204,7 +204,9 @@ $(document).ready(function() {
 
 $(document).ready(function() {
     // Add copy to clipboard snippets
-    $('.org-src-container').prepend('<div class="snippet-copy-to-clipboard"><span class="copy-to-clipboard-button">[copy]</span></div>');
+    $('.org-src-container pre.src').each(function() {
+        $(this).append('<div class="snippet-copy-to-clipboard"><span class="copy-to-clipboard-button">[copy]</span></div>');
+    });
 
     // Display/hide snippets on source block mouseenter/mouseleave
     $(document).on('mouseenter', '.org-src-container', function () {
@@ -215,21 +217,28 @@ $(document).ready(function() {
     });
 
     $('.copy-to-clipboard-button').click( function() {
-        var element = $(this).parent().parent().find('.src');
-        var val = element.text();
+        // Get the pre element
+        var preElement = $(this).closest('pre.src');
+
+        // Clone it and remove the copy button from the clone
+        var clone = preElement.clone();
+        clone.find('.snippet-copy-to-clipboard').remove();
+
+        // Get the text from the cleaned clone
+        var val = clone.text();
         val = val.replace(/\n/g, "\r\n");
-        
+
         var $copyElement = $("<textarea>");
         $("body").append($copyElement);
 
         $copyElement.val(val);
-        
+
         $copyElement.trigger('select');
         document.execCommand('copy');
-        
+
         $copyElement.remove();
 
-        $(this).parent().parent().find('.snippet-copy-to-clipboard').hide();
+        $(this).closest('.snippet-copy-to-clipboard').hide();
     });
 });
 


### PR DESCRIPTION
Fixes #191 

## Issue
The copy button was appearing above captioned code blocks instead of being positioned within the code block itself.

When Org mode exports code blocks with captions, the HTML structure includes a `<label class="org-src-name">` element before the `<pre>` element. The previous implementation used `prepend()` on `.org-src-container`, which inserted the copy button before the label, causing it to appear above the caption rather than within the code block area.

## Solution
This PR implements three key changes:

1. **Changed button insertion method**: Modified from `prepend()` on the container to `append()` on the `pre.src` element. This ensures the button is always placed inside the code block, regardless of whether a caption is present.

2. **Added relative positioning to pre.src**: Added CSS rule to position `pre.src` relatively, ensuring the absolutely positioned button is placed correctly relative to the code block itself.

3. **Improved copy handler**: Updated the click handler to:
   - Use `closest()` instead of `parent().parent()` for more reliable DOM traversal
   - Clone the `pre` element before extracting text to exclude the copy button text from the copied content

## Result
The copy button now appears consistently in the top-right corner of all code blocks, with or without captions.

## Testing
Tested with:
- Code blocks with captions
- Code blocks without captions
- Long captions that wrap to multiple lines